### PR TITLE
Add new devices

### DIFF
--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -249,6 +249,24 @@
         "Europe"
       ],
       "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Motion Sensor 2 Pet",
+      "fullName": "frient Motion Sensor 2 Pet",
+      "modelNumber": "MOSZB-156",
+      "protocol": [
+        "Zigbee"
+      ],
+      "websiteLink": "https://www.frient.com/products/motion-sensor-2-pet",
+      "deviceType": "Sensor",
+      "secondaryDeviceType": [
+        "Motion"
+      ],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
     }
   ]
 }

--- a/_data/devices/heatit.json
+++ b/_data/devices/heatit.json
@@ -3,8 +3,8 @@
   "brand": "heatit",
   "devices": [
     {
-      "deviceName": "Z-Push Wall Controller",
-      "fullName": "Heatit Z-Push Wall Controller",
+      "deviceName": "Z-Push Wall Controller White RAL 9010 Glossy",
+      "fullName": "Heatit Z-Push Wall Controller White RAL 9010 Glossy",
       "modelNumber": "",
       "protocol": [
         "Z-Wave"
@@ -21,8 +21,44 @@
       "functionalityRemark": ""
     },
     {
-      "deviceName": "Z-Temp3",
-      "fullName": "Heatit Z-Temp3",
+      "deviceName": "Z-Push Wall Controller White RAL 9003 Glossy",
+      "fullName": "Heatit Z-Push Wall Controller White RAL 9003 Glossy",
+      "modelNumber": "",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://shop.heatit.com/product/10222/products/controllers/heatit-z-push-wall-controller-white-ral-9003-glossy/1107",
+      "deviceType": "Switch",
+      "secondaryDeviceType": [
+        "Wall"
+      ],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Z-Push Wall Controller Black Matt",
+      "fullName": "Heatit Z-Push Wall Controller Black Matt",
+      "modelNumber": "",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://shop.heatit.com/product/10190/products/controllers/heatit-z-push-wall-controller-black-matt/1107",
+      "deviceType": "Switch",
+      "secondaryDeviceType": [
+        "Wall"
+      ],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Z-Temp3 White RAL 9003",
+      "fullName": "Heatit Z-Temp3 White RAL 9003",
       "modelNumber": "",
       "protocol": [
         "Z-Wave"
@@ -37,13 +73,45 @@
       "functionalityRemark": ""
     },
     {
-      "deviceName": "Z-TRM6 DC",
-      "fullName": "Heatit Z-TRM6 DC",
+      "deviceName": "Z-Temp3 Black Matt",
+      "fullName": "Heatit Z-Temp3 Black Matt",
+      "modelNumber": "",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://shop.heatit.com/product/10290/heatit-z-temp3-black-matt",
+      "deviceType": "Climate",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Z-TRM6 DC White",
+      "fullName": "Heatit Z-TRM6 DC White",
       "modelNumber": "",
       "protocol": [
         "Z-Wave"
       ],
       "websiteLink": "https://heatit.com/produkt/10413/heatit-z-trm6-dc-white-ral-9003",
+      "deviceType": "Climate",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Z-TRM6 DC Black Matt",
+      "fullName": "Heatit Z-TRM6 DC Black Matt",
+      "modelNumber": "",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://shop.heatit.com/product/10316/products/thermostats/heatit-z-trm6-black-matt/1109",
       "deviceType": "Climate",
       "secondaryDeviceType": [],
       "relatedProducts": "",

--- a/_data/devices/zooz.json
+++ b/_data/devices/zooz.json
@@ -361,6 +361,57 @@
         "USA"
       ],
       "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
+    },
+    {
+      "deviceName": "Power Switch",
+      "fullName": "Zooz Power Switch",
+      "modelNumber": "ZEN15",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://www.getzooz.com/zooz-zen15-power-switch/",
+      "deviceType": "Switch",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Europe",
+        "USA"
+      ],
+      "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
+    },
+    {
+      "deviceName": "S2 Toggle Switch",
+      "fullName": "Zooz S2 Toggle Switch",
+      "modelNumber": "ZEN73",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://www.getzooz.com/zooz-zen73-s2-toggle-switch/",
+      "deviceType": "Switch",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Europe",
+        "USA"
+      ],
+      "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
+    },
+    {
+      "deviceName": "Heavy Duty Wall Switch",
+      "fullName": "Zooz Heavy Duty Wall Switch",
+      "modelNumber": "ZEN75",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://www.getzooz.com/zen75-heavy-duty-wall-switch/",
+      "deviceType": "Switch",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Europe",
+        "USA"
+      ],
+      "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
     }
   ]
 }


### PR DESCRIPTION
Added new devices across three brand files:

- frient — added 1: Motion Sensor 2 Pet (MOSZB-156)
- Heatit — replaced 6 consolidated entries with 10 variant-level entries (color/finish variants for Z-Push Wall Controller, Z-Temp3, Z-TRM6 DC; plus Z-Smoke 2, Z-HAN2, ZM Thermostat 16A unchanged)
- Zooz — added 3: Power Switch (ZEN15), S2 Toggle Switch (ZEN73), Heavy Duty Wall Switch (ZEN75)