### PR TITLE
Fix Frient devices

### DIFF
--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -233,7 +233,7 @@
     {
       "deviceName": "Motion Sensor 2 Pet",
       "fullName": "frient Motion Sensor 2 Pet",
-      "modelNumber": "MOSZB-156",
+      "modelNumber": "MOSZB-153",
       "protocol": [
         "Zigbee"
       ],

--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -3,26 +3,6 @@
   "brand": "frient",
   "devices": [
     {
-      "deviceName": "Motion Sensor Pro",
-      "fullName": "frient Motion Sensor Pro",
-      "modelNumber": "MOSZB-141",
-      "protocol": [
-        "Zigbee"
-      ],
-      "websiteLink": "https://www.frient.com/products/motion-sensor-pro",
-      "deviceType": "Sensor",
-      "secondaryDeviceType": [
-        "Motion",
-        "Light",
-        "Temperature"
-      ],
-      "relatedProducts": "",
-      "region": [
-        "Europe"
-      ],
-      "functionalityRemark": ""
-    },
-    {
       "deviceName": "IO Module",
       "fullName": "frient IO Module",
       "modelNumber": "IOMZB-110",

--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -73,7 +73,7 @@
     {
       "deviceName": "Smart Siren EU",
       "fullName": "frient Smart Siren EU",
-      "modelNumber": "SIRZB-110",
+      "modelNumber": "SIRZB-111",
       "protocol": [
         "Zigbee"
       ],


### PR DESCRIPTION
This fixes three issues with the Frient devices:
- The "Motion Sensor Pro" was not tested or certified and has been removed
  (Side note: It was also incorrectly named `MOSZB-141`. The correct model for the "Motion Sensor Pro" is: `MOSZB-140`)
  - Note: We should now also support both the `MOSZB-140` and `MOSZB-141` since https://github.com/zigpy/zha-device-handlers/pull/4427. They've just not been tested officially.
- The "Motion Sensor 2 Pet" had the model number of the "Alarm Motion Sensor 2", which was not tested or certified.
- The "Smart Siren EU" model number was changed to `SIRZB-111`, as `SIRZB-110` is for the EU smart siren.