### PR TITLE
Various product updates

### DIFF
--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -14,7 +14,8 @@
       "secondaryDeviceType": [],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -48,7 +49,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -100,7 +102,8 @@
       "secondaryDeviceType": [],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": "RFID tag reader is not exposed in Home Assistant"
     },
@@ -118,7 +121,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -136,7 +140,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -154,7 +159,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -208,7 +214,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -226,7 +233,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     },
@@ -244,7 +252,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     }

--- a/_data/devices/ultraloq.json
+++ b/_data/devices/ultraloq.json
@@ -3,8 +3,8 @@
   "brand": "ultraloq",
   "devices": [
     {
-      "deviceName": "U Bolt (Z-Wave Version)",
-      "fullName": "Ultraloq U Bolt (Z-Wave Version)",
+      "deviceName": "Bolt Z-Wave",
+      "fullName": "Ultraloq Bolt Z-Wave",
       "modelNumber": "",
       "protocol": [
         "Z-Wave"

--- a/_data/devices/zooz.json
+++ b/_data/devices/zooz.json
@@ -412,6 +412,27 @@
         "USA"
       ],
       "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
+    },
+    {
+      "deviceName": "Outdoor Motion Sensor",
+      "fullName": "Zooz Outdoor Motion Sensor",
+      "modelNumber": "ZSE70",
+      "protocol": [
+        "Z-Wave"
+      ],
+      "websiteLink": "https://www.getzooz.com/zse70-outdoor-motion-sensor/",
+      "deviceType": "Sensor",
+      "secondaryDeviceType": [
+        "Motion",
+        "Temperature",
+        "Light"
+      ],
+      "relatedProducts": "",
+      "region": [
+        "Europe",
+        "USA"
+      ],
+      "functionalityRemark": "Most Zooz products are now available with Z-Wave Long Range, depending on your region."
     }
   ]
 }


### PR DESCRIPTION
- Frient: added USA region to 9 devices now available in the US (Entry Sensor 2 Pro, Smart Button, Smart Humidity Sensor, Intelligent Keypad, Water Leak Detector, Water Leak Detector Probe, IO Module, Electricity Meter Interface 2 LED, Motion Sensor 2 Pet).
- Ultraloq: renamed "U Bolt (Z-Wave Version)" → "Bolt Z-Wave".
- Zooz: added Outdoor Motion Sensor (ZSE70).