### PR TITLE
Re-add frient Motion Sensor Pro (`MOSZB-140`)

### DIFF
--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -273,7 +273,8 @@
       ],
       "relatedProducts": "",
       "region": [
-        "Europe"
+        "Europe",
+        "USA"
       ],
       "functionalityRemark": ""
     }

--- a/_data/devices/frient.json
+++ b/_data/devices/frient.json
@@ -256,6 +256,26 @@
         "USA"
       ],
       "functionalityRemark": ""
+    },
+    {
+      "deviceName": "Motion Sensor Pro",
+      "fullName": "frient Motion Sensor Pro",
+      "modelNumber": "MOSZB-140",
+      "protocol": [
+        "Zigbee"
+      ],
+      "websiteLink": "https://www.frient.com/products/motion-sensor-pro",
+      "deviceType": "Sensor",
+      "secondaryDeviceType": [
+        "Motion",
+        "Light",
+        "Temperature"
+      ],
+      "relatedProducts": "",
+      "region": [
+        "Europe"
+      ],
+      "functionalityRemark": ""
     }
   ]
 }


### PR DESCRIPTION
This PR re-adds the "frient Motion Sensor Pro" that was previously removed in https://github.com/home-assistant/works-with.home-assistant.io/pull/64.
Now also with the correct model number: `MOSZB-140`.

Screenshot:
<img width="959" height="85" alt="Screenshot showing new entry in WWHA device list" src="https://github.com/user-attachments/assets/823b209a-7521-43e1-973f-aeaa6663d340" />
