### PR TITLE
Update contact section copy to "Works with Home Assistant program"

### DIFF
--- a/_includes/components/contact-us.njk
+++ b/_includes/components/contact-us.njk
@@ -4,7 +4,7 @@
       <h2>Interested in working with us?</h2>
       <p>
         We’re always open to speaking about integrations or other collaborative
-        relationships as well as the Works with program. Email us and we can
+        relationships as well as the Works with Home Assistant program. Email us and we can
         tell you more about the Home Assistant universe and how you might get
         involved.
       </p>


### PR DESCRIPTION
## Summary

Updates the copy in the "Interested in working with us?" contact section to refer to the "Works with Home Assistant program" instead of the "Works with program".

## Changes

- `_includes/components/contact-us.njk`: Changed "the Works with program" to "the Works with Home Assistant program".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015jZqUBvrp5d7bbVjur6jJM)_