### PR TITLE
Add Apollo Automation H-3 Christmas Ornament to certified devices

### DIFF
--- a/_data/devices/apollo-automation.json
+++ b/_data/devices/apollo-automation.json
@@ -85,6 +85,22 @@
       "functionalityRemark": ""
     },
     {
+      "deviceName": "H-3 Christmas Ornament",
+      "fullName": "Apollo Automation H-3 Christmas Ornament",
+      "modelNumber": "H-3",
+      "protocol": [
+        "ESPHome"
+      ],
+      "websiteLink": "https://apolloautomation.com",
+      "deviceType": "Light",
+      "secondaryDeviceType": [],
+      "relatedProducts": "",
+      "region": [
+        "Worldwide"
+      ],
+      "functionalityRemark": ""
+    },
+    {
       "deviceName": "LED-1 Controller",
       "fullName": "Apollo Automation LED-1 Controller",
       "modelNumber": "LED-1",

--- a/_data/devices/apollo-automation.json
+++ b/_data/devices/apollo-automation.json
@@ -93,7 +93,9 @@
       ],
       "websiteLink": "https://apolloautomation.com",
       "deviceType": "Light",
-      "secondaryDeviceType": [],
+      "secondaryDeviceType": [
+        "Christmas"
+      ],
       "relatedProducts": "",
       "region": [
         "Worldwide"


### PR DESCRIPTION
## Summary

Adds a newly certified Apollo Automation device to the certified-products list, sourced from the Apollo Phase 3 device list (Certification = **Pass**).

## Device added

| Field | Value |
|---|---|
| Device | H-3 Christmas Ornament |
| Model | H-3 |
| Protocol | ESPHome |
| Device Type | Light |
| Region | Worldwide |

The entry was added to the existing `_data/devices/apollo-automation.json`, placed right after the H-2 ornament to keep the ornaments grouped, and follows the same schema and formatting as the other entries.

## Note

The source list only provided the base website URL (`https://apolloautomation.com`), so that value was used. The other Apollo entries link to specific product pages, so this can be updated once the exact H-3 product page URL is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TN8Sbdos5NNg4hjx4DEDBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8Sbdos5NNg4hjx4DEDBj)_