### PR TITLE
Change AirGradient One (I-9PSL) device type to Light

### DIFF
--- a/_data/devices/airgradient.json
+++ b/_data/devices/airgradient.json
@@ -10,7 +10,7 @@
         "WiFi"
       ],
       "websiteLink": "https://www.airgradient.com/indoor/",
-      "deviceType": "Sensor",
+      "deviceType": "Light",
       "secondaryDeviceType": [
         "Air quality"
       ],


### PR DESCRIPTION
Changes the `deviceType` for **AirGradient One: Indoor Air Quality Monitor** (model `I-9PSL`) from `Sensor` to `Light` in `_data/devices/airgradient.json`, as requested.

This is a one-line data change. The sibling AirGradient entry, Open Air: Outdoor Air Quality Monitor (`O-1PST`), is left as `Sensor`.

### Effect on the certified products page

`deviceType` is rendered directly as the device-type badge and the filter dropdown on `/certified-products/` is built from the values present in the data, so this device will now show a "Light" badge and appear under the **Light** filter instead of **Sensor**.

### Note for reviewers

Flagging for confirmation, since the repo has no schema validation on this field to catch it: the product is an air quality monitor and its `secondaryDeviceType` remains `Air quality`, so `Light` may read as a data error on the public table. Happy to revert to `Sensor` or use a different value if this was not the intent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqifahcFjoah1rJQXkHyre)_